### PR TITLE
Edited jquery.tablescroll.js via GitHub

### DIFF
--- a/jquery.tablescroll.js
+++ b/jquery.tablescroll.js
@@ -64,10 +64,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 		var settings = $.extend({},$.fn.tableScroll.defaults,options);
 		
 		// Bail out if there's no vertical overflow
-		if ($(this).height() <= settings.height)
-		{
-		  return this;
-		}
+		//if ($(this).height() <= settings.height)
+		//{
+		//  return this;
+		//}
 
 		settings.scrollbarWidth = getScrollbarWidth();
 


### PR DESCRIPTION
As discussed in the issue I raised, this fix needs to be applied to allow CSS to be applied for all table sizes, whether the scroll bar needs to be displayed or not.

It seems to have no impact on the rest of the tool but obviously you can review this one yourself....
