### PR TITLE
Allow jQuery.tableScroll to be re-applied without further wrapping.

### DIFF
--- a/jquery.tablescroll.js
+++ b/jquery.tablescroll.js
@@ -77,7 +77,14 @@ OTHER DEALINGS IN THE SOFTWARE.
 			
 			var tb = $(this).addClass('tablescroll_body');
 
-			var wrapper = $('<div class="tablescroll_wrapper"></div>').insertBefore(tb).append(tb);
+            // find or create the wrapper div (allows tableScroll to be re-applied)
+            var wrapper;
+            if (tb.parent().hasClass('tablescroll_wrapper')) {
+                wrapper = tb.parent();
+            }
+            else {
+                wrapper = $('<div class="tablescroll_wrapper"></div>').insertBefore(tb).append(tb);
+            }
 
 			// check for a predefined container
 			if (!wrapper.parent('div').hasClass(settings.containerClass))


### PR DESCRIPTION
Prior to this change if this plugin were re-applied the table would end up being nested further and further within wrapper divs. This caused issues when trying to resize the table in relation to the window (e.g in a jQuery(window).resize(...) event handler. The visible effect was that shrinking the table appeared to work - but growing it didn't (as tested in safari).

This change checks whether the table is already wrapped and uses the existing wrapper, if there is one, rather than making a new one each time.

I've tested the change on Safari 5.1.1 (Mac Lion), Firefox 6.0.2 (Mac Lion), and Internet Explorer 8.0.6001.18702.
