### PR TITLE
min-width vs width

### DIFF
--- a/jquery.tablescroll.js
+++ b/jquery.tablescroll.js
@@ -135,8 +135,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 			{
 				w = $(this).width();
 
-				$('th:eq('+i+'), td:eq('+i+')',thead_tr_first).css('width',w+'px');
-				$('th:eq('+i+'), td:eq('+i+')',tbody_tr_first).css('width',w+'px');
+				$('th:eq('+i+'), td:eq('+i+')',thead_tr_first).css('min-width',w+'px');
+				$('th:eq('+i+'), td:eq('+i+')',tbody_tr_first).css('min-width',w+'px');
 				if (has_tfoot) $('th:eq('+i+'), td:eq('+i+')',tfoot_tr_first).css('width',w+'px');
 			});
 


### PR DESCRIPTION
I had some trouble - which seemed to be cross-browser - where the width values in the first row of the table were not honoured (despite being set). Subsequent rows worked - just the first was wrong (was choosing "best-fit" sizes for cells).

Changing the code to set min-width rather than width fixed the issue for me.

Your mileage may vary.
